### PR TITLE
Fixed release creation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,12 +102,10 @@ jobs:
               LATEST_TAG=$(echo "$YEAR_TAGS" | head -n1)
               PATCH_VERSION=$(echo "$LATEST_TAG" | cut -d'.' -f2)
               NEXT_PATCH=$((PATCH_VERSION + 1))
-              SHORT_SHA=$(git rev-parse --short HEAD)
-              VERSION="${CURRENT_YEAR}.${NEXT_PATCH}-g${SHORT_SHA}"
+              VERSION="${CURRENT_YEAR}.${NEXT_PATCH}"
             else
               # No year tags exist, start with 2025.1
-              SHORT_SHA=$(git rev-parse --short HEAD)
-              VERSION="${CURRENT_YEAR}.1-g${SHORT_SHA}"
+              VERSION="${CURRENT_YEAR}.1"
             fi
             echo "export VERSION=${VERSION}" >> $BASH_ENV
       - run:
@@ -142,24 +140,18 @@ jobs:
             # Get the latest commit message as release notes
             COMMIT_MSG=$(git log -1 --pretty=%B)
 
-            # Check if this is already a tagged commit
-            if git describe --tags --exact-match HEAD >/dev/null 2>&1; then
-              echo "Creating release for existing tag: ${VERSION}"
-              RELEASE_FLAGS="--title \"Release $VERSION\" --notes \"$COMMIT_MSG\""
-            else
-              echo "Creating pre-release for commit: ${VERSION}"
-              RELEASE_FLAGS="--title \"Pre-release $VERSION\" --notes \"$COMMIT_MSG\" --prerelease"
-            fi
-
-            # Create GitHub release with binaries (this will create the tag automatically)
-            gh release create $VERSION $RELEASE_FLAGS \
+            # Create GitHub release
+            echo "Creating release: ${VERSION}"
+            gh release create "$VERSION" \
+              --title "Release $VERSION" \
+              --notes "$COMMIT_MSG" \
               dist/ccbm-linux-amd64 \
               dist/ccbm-darwin-amd64 \
               dist/ccbm-darwin-arm64 \
               dist/ccbm-windows-amd64.exe || {
               echo "Release creation failed. This might be because the release already exists."
               echo "Attempting to upload artifacts to existing release..."
-              gh release upload $VERSION \
+              gh release upload "$VERSION" \
                 dist/ccbm-linux-amd64 \
                 dist/ccbm-darwin-amd64 \
                 dist/ccbm-darwin-arm64 \
@@ -173,20 +165,27 @@ workflows:
   version: 2
   ci:
     jobs:
-      # Run tests and linting in parallel for all branches
-      - test
-      - lint
+      # Run only on branches
+      - test:
+          filters:
+            branches:
+              ignore: main
+      - lint:
+          filters:
+            branches:
+              ignore: main
 
-      # Build depends on both test and lint passing
+      # Run only on branches to test the build
       - build:
           requires:
             - test
             - lint
+          filters:
+            branches:
+              ignore: main
 
-      # Release only runs on main branch and depends on build
+      # Release runs only on main
       - release:
-          requires:
-            - build
           filters:
             branches:
               only: main


### PR DESCRIPTION
* removed the pre-release moniker
* removed the short SHA from the version number
* more efficient running of CircleCI steps in branch vs. main